### PR TITLE
Update main.yml to also zip the url manual file

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,10 @@ jobs:
       run: npx @showsync/amxd-tools freeze --source MTC\ project/ --dependency MTC\ project/ --target dist/
       env:
         NODE_AUTH_TOKEN: ${{ secrets.BUILD_READ_PACKAGES }}
-
+        
+    - name: add url file to artifact folder
+      run: cp _LiveMTC-Manual.url dist/_LiveMTC-Manual.url
+      
     - uses: actions/upload-artifact@v2
       with:
         name: dist


### PR DESCRIPTION
Description
-----
Updated the GitHub actions script to also zip the url link file to the downloadable artefact .

User-visible changes
--------------------
It is no longer necessary to manually add the url link file to the zip. And thus prevent the creation of a .ds store file visible to future windows users.

Risks
-----
low
